### PR TITLE
feat: build curated showroom experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+
+# Misc
+.DS_Store
+*.pem
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Supabase local cache
+/supabase
+
+# Generated exports
+/tmp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Curated Showroom Presentation
+
+A production-ready first draft of a curated B2B showroom experience built with Next.js (App Router), TypeScript, Tailwind CSS, and Zustand. The app spotlights collections, market recommendations, and collaborative selection tools without transactional flows.
+
+## Features
+
+- **Curated showroom layout** with collection hero videos, dense SKU grids, and market recommendation rows.
+- **Persistent selection panel** that tracks quantities, notes, collaborators, favorites, and provides export/share actions.
+- **Collaboration tools** including attribution prompts, favorite limits per collection, and a favorites leaderboard.
+- **Dealer personalization** via `?dealer=` param that adjusts pricing tier, previous purchases, starter selections, and on-display badges.
+- **Shareable selections** through generated tokens that open a read-only view with a duplicate-and-edit flow.
+- **Exports** for PDF (via `@react-pdf/renderer`) and CSV summary downloads.
+- **Local JSON fallback** for products, collections, dealers, and selections so the repo runs without Supabase credentials.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server starts at [http://localhost:3000](http://localhost:3000).
+
+### Demo routes
+
+- Landing page: `/`
+- Dealer experience: `/showroom?dealer=robinson`
+- Demo dealer: `/showroom?dealer=demo`
+- Shared read-only example (after generating a share token): `/showroom?share=<token>`
+
+### Data seeding
+
+Sample datasets live under `/data`:
+
+- `products.json`
+- `collections.json`
+- `dealers.json`
+- `selection.example.json`
+
+These are read directly when Supabase is not configured. Updates to a selection will overwrite `selection.example.json` in the local environment.
+
+## Supabase (optional)
+
+If you prefer using Supabase, provide the environment variables before running:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=<your-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-key>
+```
+
+With these set, the data client switches to Supabase tables (`products`, `collections`, `dealers`, `selections`, `selection_lines`).
+
+## Tests & linting
+
+The project relies on Next.js defaults. Run `npm run lint` to execute ESLint.
+
+## Export endpoints
+
+- `POST /api/export/pdf` – returns a PDF summary
+- `POST /api/export/csv` – returns a CSV summary
+
+Both endpoints expect `{ "selectionId": "..." }` in the request body.
+
+## Notes
+
+- Share links are stored in-memory when using the JSON fallback and reset when the server restarts.
+- Videos are embedded from external hosts (YouTube/Vimeo) and load lazily via `<iframe>`.
+- Tailwind CSS handles styling; adjust `tailwind.config.ts` for theme extensions.

--- a/Website
+++ b/Website
@@ -1,1 +1,0 @@
-# CuratedPresentation

--- a/data/collections.json
+++ b/data/collections.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "aurora",
+    "name": "Aurora Statement Pendants",
+    "heroVideoUrl": "https://player.vimeo.com/video/76979871",
+    "description": "Soft, sculptural pendants inspired by evening market vignettes.",
+    "sortOrder": 1
+  },
+  {
+    "id": "atelier",
+    "name": "Atelier Mixed-Media Sconces",
+    "heroVideoUrl": "https://www.youtube.com/embed/7NOSDKb0HlU",
+    "description": "Hand-applied finishes and artisan glass for boutique displays.",
+    "sortOrder": 2
+  },
+  {
+    "id": "vista",
+    "name": "Vista Outdoor Revival",
+    "heroVideoUrl": "https://player.vimeo.com/video/137857207",
+    "description": "Coastal-inspired outdoor lighting with resilient finishes.",
+    "sortOrder": 3
+  }
+]

--- a/data/dealers.json
+++ b/data/dealers.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "robinson",
+    "name": "Robinson Lighting",
+    "priceTier": "dealer",
+    "displays": [
+      { "sku": "LIB-ATL-110", "installedAt": "Dallas Market 2024" },
+      { "sku": "LIB-VST-401" }
+    ],
+    "previouslyPurchasedSkus": ["LIB-ATL-110", "LIB-VST-401", "SAV-VST-410"],
+    "starterSelectionSkus": ["LIB-AUR-201", "LIB-ATL-110", "LIB-VST-401"]
+  },
+  {
+    "id": "demo",
+    "name": "Demo Dealer",
+    "priceTier": "msrpOnly",
+    "displays": [],
+    "previouslyPurchasedSkus": ["SAV-AUR-305"],
+    "starterSelectionSkus": ["SAV-AUR-305", "LIB-VST-420"]
+  }
+]

--- a/data/products.json
+++ b/data/products.json
@@ -1,0 +1,168 @@
+[
+  {
+    "sku": "LIB-AUR-201",
+    "title": "Halo Arc Pendant 36\"",
+    "vendor": "Lib&Co",
+    "images": [
+      "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=800&q=80"
+    ],
+    "videoUrls": ["https://player.vimeo.com/video/76979871"],
+    "specs": {
+      "Collection name": "Aurora",
+      "Number of Bulbs": 6,
+      "Finish": "Brushed Brass",
+      "size": "36\" dia",
+      "dimmable": true
+    },
+    "collectionId": "aurora",
+    "price": { "msrp": 1399, "dealerNet": 840, "map": 1299 },
+    "isNewIntro": true,
+    "isMarketRecommended": true,
+    "active": true
+  },
+  {
+    "sku": "LIB-AUR-214",
+    "title": "Lumen Cascade Pendant",
+    "vendor": "Lib&Co",
+    "images": [
+      "https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Aurora",
+      "Number of Bulbs": 4,
+      "Finish": "Frosted Nickel",
+      "size": "28\" h",
+      "dimmable": true
+    },
+    "collectionId": "aurora",
+    "price": { "msrp": 1199, "dealerNet": 720 },
+    "isNewIntro": true,
+    "active": true
+  },
+  {
+    "sku": "SAV-AUR-305",
+    "title": "Savoy Aurora Drum",
+    "vendor": "Savoy House",
+    "images": [
+      "https://images.unsplash.com/photo-1600607687920-4e2a06f18d07?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Aurora",
+      "Number of Bulbs": 5,
+      "Finish": "Cerused Oak",
+      "size": "24\" dia"
+    },
+    "collectionId": "aurora",
+    "price": { "msrp": 899, "dealerNet": 540 },
+    "active": true
+  },
+  {
+    "sku": "LIB-ATL-110",
+    "title": "Atelier Dual Sconce",
+    "vendor": "Lib&Co",
+    "images": [
+      "https://images.unsplash.com/photo-1616628188505-404edb36ab79?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Atelier",
+      "Number of Bulbs": 2,
+      "Finish": "Oxidized Brass",
+      "size": "18\" h",
+      "dimmable": true
+    },
+    "collectionId": "atelier",
+    "price": { "msrp": 599, "dealerNet": 360 },
+    "isNewIntro": true,
+    "isMarketRecommended": true,
+    "active": true
+  },
+  {
+    "sku": "LIB-ATL-118",
+    "title": "Gallery Rail Sconce",
+    "vendor": "Lib&Co",
+    "images": [
+      "https://images.unsplash.com/photo-1524758870432-af57e54afa26?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Atelier",
+      "Number of Bulbs": 1,
+      "Finish": "Patina Copper",
+      "size": "12\" h"
+    },
+    "collectionId": "atelier",
+    "price": { "msrp": 449, "dealerNet": 270 },
+    "active": true
+  },
+  {
+    "sku": "HUB-ATL-204",
+    "title": "Forge Articulated Sconce",
+    "vendor": "Hubbardton Forge",
+    "images": [
+      "https://images.unsplash.com/photo-1583257742450-7868f993191e?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Atelier",
+      "Number of Bulbs": 1,
+      "Finish": "Blackened Steel",
+      "size": "15\" h"
+    },
+    "collectionId": "atelier",
+    "price": { "msrp": 799, "dealerNet": 480 },
+    "active": true
+  },
+  {
+    "sku": "LIB-VST-401",
+    "title": "Vista Coastal Lantern Large",
+    "vendor": "Lib&Co",
+    "images": [
+      "https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Vista",
+      "Number of Bulbs": 3,
+      "Finish": "Weathered Zinc",
+      "size": "22\" h",
+      "dimmable": true
+    },
+    "collectionId": "vista",
+    "price": { "msrp": 649, "dealerNet": 390 },
+    "isMarketRecommended": true,
+    "active": true
+  },
+  {
+    "sku": "SAV-VST-410",
+    "title": "Savoy Vista Lantern",
+    "vendor": "Savoy House",
+    "images": [
+      "https://images.unsplash.com/photo-1461151304267-38535e780c79?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Vista",
+      "Number of Bulbs": 2,
+      "Finish": "Seaside Bronze",
+      "size": "18\" h"
+    },
+    "collectionId": "vista",
+    "price": { "msrp": 499, "dealerNet": 312 },
+    "active": true
+  },
+  {
+    "sku": "LIB-VST-420",
+    "title": "Vista Pathway Bollard",
+    "vendor": "Lib&Co",
+    "images": [
+      "https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=800&q=80"
+    ],
+    "specs": {
+      "Collection name": "Vista",
+      "Number of Bulbs": 1,
+      "Finish": "Coastal Slate",
+      "size": "30\" h",
+      "dimmable": false
+    },
+    "collectionId": "vista",
+    "price": { "msrp": 349, "dealerNet": 215 },
+    "isNewIntro": true,
+    "active": true
+  }
+]

--- a/data/selection.example.json
+++ b/data/selection.example.json
@@ -1,0 +1,25 @@
+{
+  "id": "demo-selection",
+  "dealerId": "robinson",
+  "name": "Market Selection (Draft)",
+  "lines": [
+    {
+      "sku": "LIB-AUR-201",
+      "qty": 2,
+      "notes": "Entry vignette hero",
+      "pickedBy": ["Sierra"],
+      "favorites": ["Sierra"],
+      "collectionId": "aurora"
+    },
+    {
+      "sku": "LIB-ATL-110",
+      "qty": 4,
+      "notes": "Refresh existing display",
+      "pickedBy": ["Jordan"],
+      "favorites": ["Jordan", "Mia"],
+      "collectionId": "atelier"
+    }
+  ],
+  "createdAt": "2024-11-01T12:00:00.000Z",
+  "updatedAt": "2024-11-03T15:35:00.000Z"
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,18 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb',
+    },
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "curatedpresentation",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@react-pdf/renderer": "^3.4.1",
+    "@supabase/supabase-js": "^2.45.4",
+    "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
+    "nanoid": "^5.0.7",
+    "next": "14.2.13",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "swr": "^2.2.5",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.18",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.13",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/api/dealers/[id]/route.ts
+++ b/src/app/api/dealers/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { getDealerProfile } from '@/lib/dataClient';
+
+export async function GET(
+  _request: Request,
+  context: { params: { id: string } }
+) {
+  const dealer = await getDealerProfile(context.params.id);
+  if (!dealer) {
+    return NextResponse.json({ dealer: null }, { status: 404 });
+  }
+  return NextResponse.json({ dealer });
+}

--- a/src/app/api/export/csv/route.ts
+++ b/src/app/api/export/csv/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getProducts, getSelectionById } from '@/lib/dataClient';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const selectionId: string | undefined = body.selectionId;
+  if (!selectionId) {
+    return NextResponse.json({ error: 'Missing selection id' }, { status: 400 });
+  }
+
+  const [selection, products] = await Promise.all([
+    getSelectionById(selectionId),
+    getProducts(),
+  ]);
+
+  if (!selection) {
+    return NextResponse.json({ error: 'Selection not found' }, { status: 404 });
+  }
+
+  const productMap = new Map(products.map((product) => [product.sku, product]));
+
+  const rows = selection.lines.map((line) => {
+    const product = productMap.get(line.sku);
+    return [
+      line.sku,
+      product?.title ?? '',
+      line.qty.toString(),
+      product?.price.dealerNet?.toString() ?? product?.price.msrp.toString() ?? '',
+      line.notes ?? '',
+    ];
+  });
+
+  const csv = [
+    ['sku', 'title', 'qty', 'price_tier', 'notes'],
+    ...rows,
+  ]
+    .map((row) => row.map((value) => `"${(value ?? '').replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="selection-${selectionId}.csv"`,
+    },
+  });
+}

--- a/src/app/api/export/pdf/route.tsx
+++ b/src/app/api/export/pdf/route.tsx
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import {
+  Document,
+  Image,
+  Page,
+  StyleSheet,
+  Text,
+  View,
+  renderToBuffer,
+} from '@react-pdf/renderer';
+import { getDealerProfile, getProducts, getSelectionById } from '@/lib/dataClient';
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 32,
+    fontSize: 10,
+    fontFamily: 'Helvetica',
+    color: '#1f2937',
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  subheading: {
+    fontSize: 12,
+    marginBottom: 16,
+  },
+  tableHeader: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+    paddingBottom: 6,
+    marginBottom: 6,
+    fontWeight: 'bold',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f1f5f9',
+  },
+  cell: {
+    flex: 1,
+    paddingRight: 8,
+  },
+  notes: {
+    marginTop: 24,
+    fontSize: 9,
+    color: '#6b7280',
+  },
+});
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const selectionId: string | undefined = body.selectionId;
+  if (!selectionId) {
+    return NextResponse.json({ error: 'Missing selection id' }, { status: 400 });
+  }
+
+  const [selection, products] = await Promise.all([
+    getSelectionById(selectionId),
+    getProducts(),
+  ]);
+
+  if (!selection) {
+    return NextResponse.json({ error: 'Selection not found' }, { status: 404 });
+  }
+
+  const dealer = await getDealerProfile(selection.dealerId);
+  const productMap = new Map(products.map((product) => [product.sku, product]));
+
+  const document = (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <Text style={styles.heading}>{selection.name}</Text>
+        <Text style={styles.subheading}>
+          Dealer: {dealer?.name ?? selection.dealerId} · Generated {new Date().toLocaleDateString()}
+        </Text>
+        <View style={styles.tableHeader}>
+          <Text style={[styles.cell, { flex: 0.8 }]}>SKU</Text>
+          <Text style={[styles.cell, { flex: 1.6 }]}>Title</Text>
+          <Text style={[styles.cell, { flex: 0.5 }]}>Qty</Text>
+          <Text style={[styles.cell, { flex: 1.2 }]}>Notes</Text>
+        </View>
+        {selection.lines.map((line) => {
+          const product = productMap.get(line.sku);
+          return (
+            <View key={line.sku} style={styles.tableRow}>
+              <View style={[styles.cell, { flex: 0.8 }]}>
+                <Text>{line.sku}</Text>
+                {product?.images?.[0] && (
+                  <Image
+                    src={product.images[0]}
+                    style={{ width: 60, height: 40, marginTop: 4, objectFit: 'cover' }}
+                  />
+                )}
+              </View>
+              <Text style={[styles.cell, { flex: 1.6 }]}>{product?.title ?? '—'}</Text>
+              <Text style={[styles.cell, { flex: 0.5 }]}>{line.qty}</Text>
+              <Text style={[styles.cell, { flex: 1.2 }]}>{line.notes ?? ''}</Text>
+            </View>
+          );
+        })}
+        <Text style={styles.notes}>
+          Non-transactional preview. Contact your rep to finalize.
+        </Text>
+      </Page>
+    </Document>
+  );
+
+  const buffer = await renderToBuffer(document);
+  return new NextResponse(buffer, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="selection-${selectionId}.pdf"`,
+    },
+  });
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getProducts } from '@/lib/dataClient';
+
+export async function GET() {
+  const products = await getProducts();
+  return NextResponse.json({ products });
+}

--- a/src/app/api/selection/[id]/route.ts
+++ b/src/app/api/selection/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { getSelectionById } from '@/lib/dataClient';
+
+export async function GET(
+  _request: Request,
+  context: { params: { id: string } }
+) {
+  const selection = await getSelectionById(context.params.id);
+  if (!selection) {
+    return NextResponse.json({ selection: null }, { status: 404 });
+  }
+  return NextResponse.json({ selection });
+}

--- a/src/app/api/selections/route.ts
+++ b/src/app/api/selections/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { getSelectionById, upsertSelection } from '@/lib/dataClient';
+import type { Selection } from '@/lib/types';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  if (!id) {
+    return NextResponse.json({ error: 'Missing selection id' }, { status: 400 });
+  }
+  const selection = await getSelectionById(id);
+  if (!selection) {
+    return NextResponse.json({ error: 'Selection not found' }, { status: 404 });
+  }
+  return NextResponse.json({ selection });
+}
+
+export async function POST(request: Request) {
+  const payload = await request.json();
+
+  if (payload.action === 'duplicate') {
+    const sourceId: string | undefined = payload.selectionId;
+    const dealerId: string | undefined = payload.dealerId;
+    if (!sourceId || !dealerId) {
+      return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });
+    }
+    const source = await getSelectionById(sourceId);
+    if (!source) {
+      return NextResponse.json({ error: 'Selection not found' }, { status: 404 });
+    }
+    const clone: Selection = {
+      ...source,
+      id: `sel_${nanoid(6)}`,
+      dealerId,
+      name: `${source.name} (Copy)`,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const saved = await upsertSelection(clone);
+    return NextResponse.json({ selection: saved });
+  }
+
+  if (!payload || !payload.id) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const selection = await upsertSelection(payload as Selection);
+  return NextResponse.json({ selection });
+}

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -1,0 +1,17 @@
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { persistShareToken } from '@/lib/dataClient';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const selectionId: string | undefined = body.selectionId;
+  if (!selectionId) {
+    return NextResponse.json({ error: 'Missing selection id' }, { status: 400 });
+  }
+  const token = nanoid(8);
+  persistShareToken(token, selectionId);
+  const origin = headers().get('origin') ?? 'http://localhost:3000';
+  const url = `${origin}/showroom?share=${token}`;
+  return NextResponse.json({ token, url });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,31 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}
+
+main {
+  @apply min-h-screen;
+}
+
+a {
+  @apply text-brand hover:text-brand-accent transition-colors;
+}
+
+.scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  @apply bg-slate-300 rounded-full;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import { Header } from '@/components/Header';
+
+export const metadata: Metadata = {
+  title: 'Curated Showroom Selections',
+  description:
+    'Dealer-ready curated showroom selections with collaborative tools and storytelling collections.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-slate-50 text-slate-900">
+        <Header />
+        <main className="min-h-[calc(100vh-4rem)] px-4 pb-16 pt-8 lg:px-8">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { ArrowRightIcon } from '@/components/icons/ArrowRightIcon';
+
+export default function HomePage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+      <span className="mb-4 inline-flex items-center rounded-full bg-brand/10 px-4 py-1 text-sm font-medium text-brand">
+        Curated, collaborative & dealer-ready
+      </span>
+      <h1 className="text-4xl font-semibold text-slate-900 md:text-5xl">
+        Story-driven showroom selections that travel with your team
+      </h1>
+      <p className="mt-6 text-lg text-slate-600">
+        Build launch assortments faster with new intros, market highlights, and
+        previous winners tailored to each dealer. Save and share selections in
+        minutes—no cart, no checkout, just ready-to-send storytelling.
+      </p>
+      <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row">
+        <Link
+          href="/showroom?dealer=robinson"
+          className="group inline-flex items-center gap-2 rounded-full bg-brand px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-brand-muted"
+        >
+          View Curated Selections
+          <ArrowRightIcon className="h-4 w-4 transition group-hover:translate-x-1" />
+        </Link>
+        <Link
+          href="/showroom"
+          className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-base font-semibold text-brand shadow-sm ring-1 ring-slate-200 transition hover:ring-brand/30"
+        >
+          Browse as guest
+        </Link>
+      </div>
+      <dl className="mt-16 grid w-full grid-cols-1 gap-6 text-left sm:grid-cols-3">
+        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <dt className="text-sm font-medium text-slate-500">Dealer-ready stories</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-900">
+            Market intros + proven winners in one view
+          </dd>
+        </div>
+        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <dt className="text-sm font-medium text-slate-500">Collaborate instantly</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-900">
+            Attribute picks, favorites, and nudges per teammate
+          </dd>
+        </div>
+        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <dt className="text-sm font-medium text-slate-500">Share in seconds</dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-900">
+            Export polished PDFs & CSV assortments
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/src/app/showroom/page.tsx
+++ b/src/app/showroom/page.tsx
@@ -1,0 +1,139 @@
+import { notFound } from 'next/navigation';
+import { nanoid } from 'nanoid';
+import { ShowroomExperience } from '@/components/ShowroomExperience';
+import {
+  getCollections,
+  getDealerProfile,
+  getProducts,
+  getSelectionById,
+  resolveShareToken,
+} from '@/lib/dataClient';
+import type { DealerProfile, Product, Selection } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+type ShowroomSearchParams = {
+  dealer?: string;
+  share?: string;
+  selection?: string;
+  view?: string;
+};
+
+export default async function ShowroomPage({
+  searchParams,
+}: {
+  searchParams: ShowroomSearchParams;
+}) {
+  const dealerId = searchParams.dealer;
+  const shareToken = searchParams.share ?? null;
+  const selectionId = searchParams.selection;
+  const highlightNewIntros = searchParams.view === 'new-intros';
+
+  const [collections, products, dealer] = await Promise.all([
+    getCollections(),
+    getProducts(),
+    dealerId ? getDealerProfile(dealerId) : Promise.resolve(null),
+  ]);
+
+  const recommended = products.filter((product) => product.isMarketRecommended).slice(0, 5);
+  const previousBest = derivePreviousBest(products, dealer);
+
+  let selection: Selection | null = null;
+  let readOnly = false;
+
+  if (shareToken) {
+    const sharedSelectionId = resolveShareToken(shareToken) ?? shareToken;
+    selection = sharedSelectionId ? await getSelectionById(sharedSelectionId) : null;
+    readOnly = true;
+  } else if (selectionId) {
+    selection = await getSelectionById(selectionId);
+  }
+
+  if (!selection && dealer) {
+    selection = buildStarterSelection(dealer, products);
+  }
+
+  if (!selection) {
+    selection = createEmptySelection(dealerId ?? 'guest');
+  }
+
+  selection = ensureCollectionMetadata(selection, products);
+
+  if (shareToken && !selection) {
+    return notFound();
+  }
+
+  return (
+    <ShowroomExperience
+      collections={collections}
+      products={products}
+      dealer={dealer}
+      recommended={recommended}
+      previousBest={previousBest}
+      initialSelection={selection}
+      readOnly={readOnly}
+      highlightNewIntros={highlightNewIntros}
+      shareToken={shareToken}
+    />
+  );
+}
+
+function derivePreviousBest(products: Product[], dealer: DealerProfile | null) {
+  if (dealer && dealer.previouslyPurchasedSkus.length > 0) {
+    const map = new Map(products.map((product) => [product.sku, product]));
+    return dealer.previouslyPurchasedSkus
+      .map((sku) => map.get(sku))
+      .filter((product): product is Product => Boolean(product))
+      .slice(0, 5);
+  }
+  return products.slice(0, 5);
+}
+
+function buildStarterSelection(dealer: DealerProfile, products: Product[]): Selection | null {
+  if (!dealer.starterSelectionSkus || dealer.starterSelectionSkus.length === 0) {
+    return null;
+  }
+  const map = new Map(products.map((product) => [product.sku, product]));
+  const lines = dealer.starterSelectionSkus
+    .map((sku) => map.get(sku))
+    .filter((product): product is Product => Boolean(product))
+    .map((product) => ({
+      sku: product.sku,
+      qty: 1,
+      notes: '',
+      pickedBy: [],
+      favorites: [],
+      collectionId: product.collectionId,
+    }));
+  return {
+    id: `sel_${nanoid(6)}`,
+    dealerId: dealer.id,
+    name: 'Market Selection (Draft)',
+    lines,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function createEmptySelection(dealerId: string): Selection {
+  const now = new Date().toISOString();
+  return {
+    id: `sel_${nanoid(6)}`,
+    dealerId,
+    name: 'Market Selection (Draft)',
+    lines: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function ensureCollectionMetadata(selection: Selection, products: Product[]): Selection {
+  const map = new Map(products.map((product) => [product.sku, product.collectionId]));
+  return {
+    ...selection,
+    lines: selection.lines.map((line) => ({
+      ...line,
+      collectionId: line.collectionId ?? map.get(line.sku),
+    })),
+  };
+}

--- a/src/components/AttributionPrompt.tsx
+++ b/src/components/AttributionPrompt.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { FormEvent, useEffect, useRef, useState } from 'react';
+
+export type AttributionPromptProps = {
+  open: boolean;
+  defaultValue?: string | null;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+};
+
+export function AttributionPrompt({
+  open,
+  defaultValue,
+  onClose,
+  onSubmit,
+}: AttributionPromptProps) {
+  const [value, setValue] = useState(defaultValue ?? '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setValue(defaultValue ?? '');
+      const timeout = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 80);
+      return () => clearTimeout(timeout);
+    }
+  }, [open, defaultValue]);
+
+  if (!open) return null;
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl"
+      >
+        <h2 className="text-lg font-semibold text-slate-900">Who&apos;s collaborating?</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          We tag picks and favorites by name so your team knows who suggested
+          what. Add your name once to keep things personal.
+        </p>
+        <label className="mt-4 block text-sm font-medium text-slate-700">
+          Your name
+        </label>
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-base shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+          placeholder="e.g. Sierra"
+        />
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full px-4 py-2 text-sm font-medium text-slate-500 hover:text-slate-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-full bg-brand px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-muted"
+          >
+            Let&apos;s go
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/CollectionSection.tsx
+++ b/src/components/CollectionSection.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from 'react';
+import { SkuCard } from './SkuCard';
+import type { Collection, DealerProfile, Product } from '@/lib/types';
+
+export type CollectionSectionProps = {
+  collection: Collection;
+  products: Product[];
+  dealer?: DealerProfile | null;
+  previouslyPurchased?: string[];
+};
+
+export function CollectionSection({
+  collection,
+  products,
+  dealer,
+  previouslyPurchased = [],
+}: CollectionSectionProps) {
+  if (!products.length) return null;
+
+  return (
+    <section id={collection.id} className="mt-16 space-y-8">
+      <div className="overflow-hidden rounded-3xl bg-slate-900 text-white shadow-lg">
+        {collection.heroVideoUrl ? (
+          <div className="aspect-video w-full">
+            <iframe
+              src={collection.heroVideoUrl}
+              className="h-full w-full"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowFullScreen
+              loading="lazy"
+              title={`${collection.name} hero video`}
+            />
+          </div>
+        ) : (
+          <div className="flex aspect-video items-center justify-center bg-gradient-to-r from-brand to-brand-muted">
+            <p className="text-xl font-semibold">{collection.name}</p>
+          </div>
+        )}
+        <div className="space-y-3 px-6 pb-6 pt-4">
+          <h2 className="text-2xl font-semibold">{collection.name}</h2>
+          {collection.description && (
+            <p className="max-w-3xl text-sm text-slate-200">{collection.description}</p>
+          )}
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {products.map((product) => (
+          <Suspense key={product.sku} fallback={null}>
+            <SkuCard
+              product={product}
+              dealer={dealer}
+              isPreviouslyPurchased={previouslyPurchased.includes(product.sku)}
+            />
+          </Suspense>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+export type ExportMenuProps = {
+  selectionId?: string;
+  disabled?: boolean;
+};
+
+export function ExportMenu({ selectionId, disabled }: ExportMenuProps) {
+  const [isLoading, setIsLoading] = useState<'pdf' | 'csv' | null>(null);
+
+  const handleExport = async (format: 'pdf' | 'csv') => {
+    if (!selectionId) return;
+    setIsLoading(format);
+    try {
+      const response = await fetch(`/api/export/${format}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ selectionId }),
+      });
+      if (!response.ok) {
+        throw new Error('Export failed');
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `selection-${selectionId}.${format}`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error(error);
+      alert('Export is unavailable right now.');
+    } finally {
+      setIsLoading(null);
+    }
+  };
+
+  return (
+    <div className="inline-flex gap-2">
+      <button
+        type="button"
+        disabled={disabled || !selectionId || isLoading === 'pdf'}
+        onClick={() => handleExport('pdf')}
+        className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+      >
+        {isLoading === 'pdf' ? 'Exporting…' : 'Export PDF'}
+      </button>
+      <button
+        type="button"
+        disabled={disabled || !selectionId || isLoading === 'csv'}
+        onClick={() => handleExport('csv')}
+        className="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-brand/40 hover:text-brand disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-300"
+      >
+        {isLoading === 'csv' ? 'Exporting…' : 'Export CSV'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/80 backdrop-blur">
+      <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-4 sm:px-6">
+        <Link href="/" className="text-lg font-semibold text-brand">
+          Lib&Co Showroom
+        </Link>
+        <nav className="hidden items-center gap-6 text-sm font-medium text-slate-600 md:flex">
+          <Link href="/" className="hover:text-brand">
+            Home
+          </Link>
+          <Link href="/showroom" className="hover:text-brand">
+            All Collections
+          </Link>
+          <a href="#search" className="hover:text-brand">
+            Search
+          </a>
+          <a href="#selection" className="hover:text-brand">
+            My Selection
+          </a>
+        </nav>
+        <Link
+          href="/showroom?dealer=robinson"
+          className="hidden rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-muted sm:inline-flex"
+        >
+          Dealer preview
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/src/components/RecommendationRow.tsx
+++ b/src/components/RecommendationRow.tsx
@@ -1,0 +1,40 @@
+import type { DealerProfile, Product } from '@/lib/types';
+import { SkuCard } from './SkuCard';
+
+export type RecommendationRowProps = {
+  title: string;
+  subtitle?: string;
+  products: Product[];
+  dealer?: DealerProfile | null;
+  previouslyPurchased?: string[];
+};
+
+export function RecommendationRow({
+  title,
+  subtitle,
+  products,
+  dealer,
+  previouslyPurchased = [],
+}: RecommendationRowProps) {
+  if (!products.length) return null;
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900">{title}</h2>
+          {subtitle && <p className="text-sm text-slate-500">{subtitle}</p>}
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {products.map((product) => (
+          <SkuCard
+            key={product.sku}
+            product={product}
+            dealer={dealer}
+            isPreviouslyPurchased={previouslyPurchased.includes(product.sku)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/SelectionInitializer.tsx
+++ b/src/components/SelectionInitializer.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { Selection } from '@/lib/types';
+import { useSelectionStore } from '@/hooks/useSelectionStore';
+
+export type SelectionInitializerProps = {
+  selection: Selection | null;
+};
+
+export function SelectionInitializer({ selection }: SelectionInitializerProps) {
+  const initialize = useSelectionStore((state) => state.initialize);
+
+  useEffect(() => {
+    if (selection) {
+      initialize(selection);
+    }
+  }, [initialize, selection]);
+
+  return null;
+}

--- a/src/components/SelectionPanel.tsx
+++ b/src/components/SelectionPanel.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { useAttributionName } from '@/hooks/useAttribution';
+import { useSelectionStore } from '@/hooks/useSelectionStore';
+import type { Product } from '@/lib/types';
+import { AttributionPrompt } from './AttributionPrompt';
+import { ExportMenu } from './ExportMenu';
+import { ShareDialog } from './ShareDialog';
+
+export type SelectionPanelProps = {
+  products: Product[];
+  readOnly?: boolean;
+};
+
+export function SelectionPanel({ products, readOnly = false }: SelectionPanelProps) {
+  const selection = useSelectionStore((state) => state.selection);
+  const collaborators = useSelectionStore((state) => state.collaborators);
+  const updateQty = useSelectionStore((state) => state.updateQty);
+  const updateNotes = useSelectionStore((state) => state.updateNotes);
+  const removeLine = useSelectionStore((state) => state.removeLine);
+  const clear = useSelectionStore((state) => state.clear);
+  const replaceSelection = useSelectionStore((state) => state.replaceSelection);
+  const setCollaborator = useSelectionStore((state) => state.setCollaborator);
+
+  const { name, saveName, ready } = useAttributionName();
+  const [promptOpen, setPromptOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<null | ((resolvedName: string) => void)>(null);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<'selection' | 'leaderboard'>('selection');
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const skuMap = useMemo(() => new Map(products.map((product) => [product.sku, product])), [products]);
+
+  const lines = selection?.lines ?? [];
+  const totalItems = lines.reduce((sum, line) => sum + line.qty, 0);
+
+  const leaderboard = useMemo(() => {
+    return [...lines]
+      .map((line) => ({
+        sku: line.sku,
+        favorites: line.favorites.length,
+        title: skuMap.get(line.sku)?.title ?? line.sku,
+      }))
+      .filter((item) => item.favorites > 0)
+      .sort((a, b) => b.favorites - a.favorites);
+  }, [lines, skuMap]);
+
+  const newIntroCount = useMemo(
+    () => lines.filter((line) => skuMap.get(line.sku)?.isNewIntro).length,
+    [lines, skuMap]
+  );
+
+  const storytellingCollection = useMemo(() => {
+    const introLine = lines.find((line) => skuMap.get(line.sku)?.isNewIntro);
+    if (!introLine) return null;
+    const product = skuMap.get(introLine.sku);
+    return (
+      product?.specs['Collection name'] ?? product?.collectionId ?? 'this collection'
+    );
+  }, [lines, skuMap]);
+
+  const ensureName = (action: (resolvedName: string) => void) => {
+    if (readOnly) {
+      action(name ?? '');
+      return;
+    }
+    if (name) {
+      action(name);
+    } else if (ready) {
+      setPendingAction(() => action);
+      setPromptOpen(true);
+    }
+  };
+
+  const handleQtyChange = (sku: string, qty: number) => {
+    if (!selection || readOnly) return;
+    ensureName((actor) => {
+      updateQty(sku, qty);
+      setCollaborator(actor);
+    });
+  };
+
+  const handleNotesChange = (sku: string, notes: string) => {
+    if (!selection || readOnly) return;
+    ensureName((actor) => {
+      updateNotes(sku, notes);
+      setCollaborator(actor);
+    });
+  };
+
+  const handleRemove = (sku: string) => {
+    if (readOnly) return;
+    ensureName(() => removeLine(sku));
+  };
+
+  const handleClear = () => {
+    if (readOnly) return;
+    ensureName(() => clear());
+  };
+
+  const handleSave = async () => {
+    if (!selection || readOnly) return;
+    setSaveStatus('saving');
+    try {
+      const response = await fetch('/api/selections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(selection),
+      });
+      if (!response.ok) throw new Error('Save failed');
+      const json = await response.json();
+      replaceSelection(json.selection);
+      setSaveStatus('success');
+      setTimeout(() => setSaveStatus('idle'), 3000);
+    } catch (error) {
+      console.error(error);
+      setSaveStatus('error');
+      setTimeout(() => setSaveStatus('idle'), 4000);
+    }
+  };
+
+  const panelContent = (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">My Selection</h2>
+          <p className="text-xs text-slate-500">
+            {lines.length} SKU{lines.length === 1 ? '' : 's'} · {totalItems} item{totalItems === 1 ? '' : 's'}
+          </p>
+        </div>
+        {!readOnly && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-xs font-semibold text-rose-500 hover:text-rose-600"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {newIntroCount >= 5 && storytellingCollection && (
+        <p className="mt-3 rounded-2xl bg-brand/10 px-4 py-3 text-xs font-medium text-brand">
+          Nice picks—dealers often pair these with a storytelling piece from {storytellingCollection}. Want a suggestion?
+        </p>
+      )}
+
+      <div className="mt-4 flex space-x-2 rounded-full bg-slate-100 p-1 text-sm font-semibold text-slate-500">
+        <button
+          type="button"
+          className={clsx('flex-1 rounded-full px-3 py-2', activeTab === 'selection' && 'bg-white text-slate-900 shadow')}
+          onClick={() => setActiveTab('selection')}
+        >
+          Selection
+        </button>
+        <button
+          type="button"
+          className={clsx('flex-1 rounded-full px-3 py-2', activeTab === 'leaderboard' && 'bg-white text-slate-900 shadow')}
+          onClick={() => setActiveTab('leaderboard')}
+        >
+          Leaderboard
+        </button>
+      </div>
+
+      <div className="mt-4 flex-1 space-y-4 overflow-y-auto pr-1 text-sm">
+        {activeTab === 'selection' ? (
+          lines.length === 0 ? (
+            <p className="rounded-2xl bg-slate-100 p-6 text-center text-slate-500">
+              Nothing selected yet. Tap a SKU to get started.
+            </p>
+          ) : (
+            lines.map((line) => {
+              const product = skuMap.get(line.sku);
+              const collectionLabel = product?.specs['Collection name'] ?? product?.collectionId ?? 'Collection';
+              return (
+                <div
+                  key={line.sku}
+                  className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                        {collectionLabel}
+                      </p>
+                      <h3 className="text-base font-semibold text-slate-900">
+                        {product?.title ?? line.sku}
+                      </h3>
+                      <p className="text-xs text-slate-500">SKU {line.sku}</p>
+                    </div>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(line.sku)}
+                        className="text-xs font-semibold text-rose-500 hover:text-rose-600"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                  <div className="mt-3 flex items-center gap-3 text-sm">
+                    <label className="text-slate-500">Qty</label>
+                    <div className="flex items-center gap-2 rounded-full border border-slate-200 px-2 py-1">
+                      <button
+                        type="button"
+                        onClick={() => handleQtyChange(line.sku, Math.max(1, line.qty - 1))}
+                        className="h-6 w-6 rounded-full bg-slate-100 text-center text-base font-semibold text-slate-600"
+                        disabled={readOnly}
+                      >
+                        −
+                      </button>
+                      <span className="min-w-[2ch] text-center font-semibold text-slate-700">{line.qty}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleQtyChange(line.sku, line.qty + 1)}
+                        className="h-6 w-6 rounded-full bg-brand/10 text-center text-base font-semibold text-brand"
+                        disabled={readOnly}
+                      >
+                        +
+                      </button>
+                    </div>
+                  </div>
+                  <div className="mt-3">
+                    <label className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+                      Notes
+                    </label>
+                    <textarea
+                      value={line.notes ?? ''}
+                      onChange={(event) => handleNotesChange(line.sku, event.target.value)}
+                      className="mt-2 w-full rounded-2xl border border-slate-200 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+                      rows={3}
+                      placeholder="Add context for the buyer…"
+                      disabled={readOnly}
+                    />
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                    <span className="font-semibold text-slate-600">Picked by:</span>
+                    {line.pickedBy.length === 0 ? (
+                      <span className="rounded-full bg-slate-100 px-2 py-1">Unclaimed</span>
+                    ) : (
+                      line.pickedBy.map((person) => (
+                        <span key={person} className="rounded-full bg-brand/10 px-2 py-1 text-brand">
+                          {person}
+                        </span>
+                      ))
+                    )}
+                    {line.favorites.length > 0 && (
+                      <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-amber-700">
+                        ★ {line.favorites.length}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )
+        ) : (
+          <div className="space-y-3">
+            {leaderboard.length === 0 ? (
+              <p className="rounded-2xl bg-slate-100 p-6 text-center text-slate-500">
+                Favorites will appear here once your team stars a few showstoppers.
+              </p>
+            ) : (
+              leaderboard.map((item, index) => (
+                <div
+                  key={item.sku}
+                  className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white p-3 shadow-sm"
+                >
+                  <div>
+                    <p className="text-xs font-semibold text-slate-400">#{index + 1}</p>
+                    <p className="text-sm font-semibold text-slate-900">{item.title}</p>
+                    <p className="text-xs text-slate-500">SKU {item.sku}</p>
+                  </div>
+                  <span className="rounded-full bg-amber-100 px-3 py-1 text-sm font-semibold text-amber-700">
+                    ★ {item.favorites}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 space-y-4 border-t border-slate-200 pt-4">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setShareOpen(true)}
+            disabled={lines.length === 0}
+            className="flex-1 rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-brand/40 hover:text-brand disabled:cursor-not-allowed disabled:text-slate-300"
+          >
+            Share
+          </button>
+          <ExportMenu selectionId={selection?.id} disabled={lines.length === 0} />
+        </div>
+        {!readOnly && (
+          <button
+            type="button"
+            onClick={() => ensureName(() => handleSave())}
+            className="w-full rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-muted"
+          >
+            {saveStatus === 'saving'
+              ? 'Saving…'
+              : saveStatus === 'success'
+                ? 'Saved!'
+                : saveStatus === 'error'
+                  ? 'Retry save'
+                  : 'Save selection'}
+          </button>
+        )}
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+            Collaborators
+          </h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {collaborators.length === 0 ? (
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-500">
+                Add your name when you edit to join the roster.
+              </span>
+            ) : (
+              collaborators.map((person) => (
+                <span key={person} className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand/10 text-sm font-semibold text-brand">
+                  {getInitials(person)}
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <aside id="selection" className="lg:sticky lg:top-24 lg:h-[calc(100vh-8rem)]">
+      <div className="hidden h-full rounded-3xl border border-slate-200 bg-white p-5 shadow-lg lg:block">
+        {panelContent}
+      </div>
+      <div className="lg:hidden">
+        <button
+          type="button"
+          onClick={() => setMobileOpen(true)}
+          className="fixed bottom-6 right-6 inline-flex items-center gap-2 rounded-full bg-brand px-5 py-3 text-sm font-semibold text-white shadow-xl"
+        >
+          My Selection ({lines.length})
+        </button>
+        {mobileOpen && (
+          <div className="fixed inset-0 z-40 flex flex-col bg-slate-900/60">
+            <div className="mt-auto rounded-t-3xl bg-white p-5 shadow-2xl">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-slate-900">My Selection</h2>
+                <button
+                  type="button"
+                  onClick={() => setMobileOpen(false)}
+                  className="text-sm font-semibold text-slate-500"
+                >
+                  Close
+                </button>
+              </div>
+              <div className="max-h-[70vh] overflow-y-auto pr-1">{panelContent}</div>
+            </div>
+          </div>
+        )}
+      </div>
+      <AttributionPrompt
+        open={promptOpen}
+        defaultValue={name}
+        onClose={() => {
+          setPromptOpen(false);
+          setPendingAction(null);
+        }}
+        onSubmit={(value) => {
+          saveName(value);
+          setPromptOpen(false);
+          pendingAction?.(value);
+          setPendingAction(null);
+        }}
+      />
+      <ShareDialog
+        open={shareOpen}
+        selectionId={selection?.id}
+        onClose={() => setShareOpen(false)}
+      />
+    </aside>
+  );
+}
+
+function getInitials(name: string) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase())
+    .slice(0, 2)
+    .join('');
+}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type ShareDialogProps = {
+  open: boolean;
+  selectionId?: string;
+  onClose: () => void;
+};
+
+type ShareResponse = {
+  url: string;
+};
+
+export function ShareDialog({ open, selectionId, onClose }: ShareDialogProps) {
+  const [shareUrl, setShareUrl] = useState<string>('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'copied' | 'error'>('idle');
+
+  useEffect(() => {
+    if (!open || !selectionId) return;
+    let active = true;
+    setStatus('loading');
+    fetch('/api/share', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ selectionId }),
+    })
+      .then((res) => res.json() as Promise<ShareResponse>)
+      .then((data) => {
+        if (!active) return;
+        setShareUrl(data.url);
+        setStatus('idle');
+      })
+      .catch(() => {
+        if (!active) return;
+        setStatus('error');
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, selectionId]);
+
+  if (!open) return null;
+
+  const copyLink = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setStatus('copied');
+    } catch (error) {
+      console.error(error);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/60 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <h2 className="text-lg font-semibold text-slate-900">Shared! Copy this link to invite your team.</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          Anyone with the link can view this selection. They can duplicate it to
+          keep collaborating.
+        </p>
+        <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+          {status === 'loading' ? 'Generating link…' : shareUrl}
+        </div>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full px-4 py-2 text-sm font-medium text-slate-500 hover:text-slate-700"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            onClick={copyLink}
+            className="rounded-full bg-brand px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-muted"
+          >
+            {status === 'copied' ? 'Copied!' : 'Copy link'}
+          </button>
+        </div>
+        {status === 'error' && (
+          <p className="mt-2 text-xs text-rose-500">
+            Unable to generate link right now. Please try again.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ShowroomExperience.tsx
+++ b/src/components/ShowroomExperience.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { CollectionSection } from './CollectionSection';
+import { RecommendationRow } from './RecommendationRow';
+import { SelectionPanel } from './SelectionPanel';
+import { SelectionInitializer } from './SelectionInitializer';
+import type {
+  Collection,
+  DealerProfile,
+  Product,
+  Selection,
+} from '@/lib/types';
+import { useSelectionStore } from '@/hooks/useSelectionStore';
+
+export type ShowroomExperienceProps = {
+  collections: Collection[];
+  products: Product[];
+  dealer?: DealerProfile | null;
+  recommended: Product[];
+  previousBest: Product[];
+  initialSelection: Selection | null;
+  readOnly?: boolean;
+  highlightNewIntros?: boolean;
+  shareToken?: string | null;
+};
+
+export function ShowroomExperience({
+  collections,
+  products,
+  dealer,
+  recommended,
+  previousBest,
+  initialSelection,
+  readOnly,
+  highlightNewIntros,
+  shareToken,
+}: ShowroomExperienceProps) {
+  const [search, setSearch] = useState('');
+  const [locked, setLocked] = useState(Boolean(readOnly));
+  const [shareBannerDismissed, setShareBannerDismissed] = useState(false);
+  const replaceSelection = useSelectionStore((state) => state.replaceSelection);
+
+  const filteredProducts = useMemo(() => {
+    if (!search) return products;
+    const query = search.toLowerCase();
+    return products.filter((product) => {
+      if (product.title.toLowerCase().includes(query)) return true;
+      if (product.sku.toLowerCase().includes(query)) return true;
+      if (product.collectionId.toLowerCase().includes(query)) return true;
+      return Object.entries(product.specs).some(([key, value]) => {
+        return (
+          key.toLowerCase().includes(query) ||
+          String(value).toLowerCase().includes(query)
+        );
+      });
+    });
+  }, [products, search]);
+
+  const productsByCollection = useMemo(() => {
+    const map = new Map<string, Product[]>();
+    for (const product of filteredProducts) {
+      if (highlightNewIntros && !product.isNewIntro) continue;
+      const arr = map.get(product.collectionId) ?? [];
+      arr.push(product);
+      map.set(product.collectionId, arr);
+    }
+    return map;
+  }, [filteredProducts, highlightNewIntros]);
+
+  const previouslyPurchasedSkus = dealer?.previouslyPurchasedSkus ?? [];
+
+  const duplicateAndEdit = async () => {
+    if (!initialSelection) return;
+    try {
+      const response = await fetch('/api/selections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'duplicate',
+          selectionId: initialSelection.id,
+          dealerId: dealer?.id ?? initialSelection.dealerId,
+        }),
+      });
+      if (!response.ok) throw new Error('Duplicate failed');
+      const json = await response.json();
+      replaceSelection(json.selection);
+      setLocked(false);
+    } catch (error) {
+      console.error(error);
+      alert('Unable to duplicate right now. Try again in a moment.');
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1fr)_360px]">
+      <SelectionInitializer selection={initialSelection} />
+      <section className="lg:col-span-1">
+        <div id="search" className="sticky top-0 z-10 bg-slate-50 pb-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-3xl font-semibold text-slate-900">
+                {dealer ? `Welcome back—here’s your Market Selection.` : 'Curated showroom collections'}
+              </h1>
+              {dealer && (
+                <p className="text-sm text-slate-500">
+                  Viewing {dealer.name} · Pricing tier: {dealer.priceTier === 'dealer' ? 'Dealer net' : 'MSRP only'}
+                </p>
+              )}
+            </div>
+            {locked && shareToken && (
+              <button
+                type="button"
+                onClick={duplicateAndEdit}
+                className="inline-flex items-center gap-2 rounded-full bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-muted"
+              >
+                Duplicate &amp; Edit
+              </button>
+            )}
+          </div>
+          <div className="mt-6 flex flex-col gap-3 md:flex-row md:items-center">
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="w-full rounded-full border border-slate-200 px-4 py-2 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/30"
+              placeholder="Search by SKU, collection, finish, bulbs…"
+            />
+            {highlightNewIntros && (
+              <span className="inline-flex items-center rounded-full bg-brand/10 px-4 py-2 text-sm font-medium text-brand">
+                Showing new intros only
+              </span>
+            )}
+          </div>
+          {locked && shareToken && !shareBannerDismissed && (
+            <div className="mt-4 rounded-2xl border border-brand/20 bg-brand/10 px-4 py-3 text-sm text-brand">
+              Read-only share view. Duplicate to keep iterating with your team.
+              <button
+                type="button"
+                className="ml-4 text-xs font-semibold underline"
+                onClick={() => setShareBannerDismissed(true)}
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-6 space-y-16">
+          <RecommendationRow
+            title="Recommended from Dallas Market"
+            subtitle="Top scanned showstoppers from the floor"
+            products={recommended}
+            dealer={dealer}
+            previouslyPurchased={previouslyPurchasedSkus}
+          />
+          <RecommendationRow
+            title="Previously Purchased Best-Sellers"
+            subtitle={dealer ? 'Tailored to your past orders' : 'Popular across dealers'}
+            products={previousBest}
+            dealer={dealer}
+            previouslyPurchased={previouslyPurchasedSkus}
+          />
+          {collections.map((collection) => (
+            <CollectionSection
+              key={collection.id}
+              collection={collection}
+              products={productsByCollection.get(collection.id) ?? []}
+              dealer={dealer}
+              previouslyPurchased={previouslyPurchasedSkus}
+            />
+          ))}
+        </div>
+      </section>
+      <div className="lg:col-span-1">
+        <SelectionPanel products={products} readOnly={locked} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/SkuCard.tsx
+++ b/src/components/SkuCard.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+import clsx from 'clsx';
+import { useAttributionName } from '@/hooks/useAttribution';
+import { useSelectionStore } from '@/hooks/useSelectionStore';
+import type { DealerProfile, Product } from '@/lib/types';
+import { AttributionPrompt } from './AttributionPrompt';
+
+export type SkuCardProps = {
+  product: Product;
+  dealer?: DealerProfile | null;
+  isPreviouslyPurchased?: boolean;
+};
+
+export function SkuCard({ product, dealer, isPreviouslyPurchased }: SkuCardProps) {
+  const selection = useSelectionStore((state) => state.selection);
+  const addLine = useSelectionStore((state) => state.addLine);
+  const toggleFavorite = useSelectionStore((state) => state.toggleFavorite);
+  const setCollaborator = useSelectionStore((state) => state.setCollaborator);
+
+  const { name, saveName, ready } = useAttributionName();
+  const [promptOpen, setPromptOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<'add' | 'favorite' | null>(null);
+  const [favoriteFeedback, setFavoriteFeedback] = useState<string | null>(null);
+  const [addFeedback, setAddFeedback] = useState<string | null>(null);
+
+  const existingLine = selection?.lines.find((line) => line.sku === product.sku);
+  const isAdded = Boolean(existingLine);
+  const isFavorited = existingLine?.favorites.includes(name ?? '') ?? false;
+
+  const ensureName = (nextAction: 'add' | 'favorite') => {
+    if (name) return true;
+    if (!ready) return false;
+    setPendingAction(nextAction);
+    setPromptOpen(true);
+    return false;
+  };
+
+  const handleAdd = (actor: string) => {
+    if (!selection) return;
+    addLine(
+      {
+        sku: product.sku,
+        qty: 1,
+        notes: existingLine?.notes,
+        pickedBy: existingLine?.pickedBy ?? [],
+        favorites: existingLine?.favorites ?? [],
+        collectionId: product.collectionId,
+      },
+      actor
+    );
+    setCollaborator(actor);
+    setAddFeedback(
+      isPreviouslyPurchased
+        ? 'You’ve carried this before—great refresh option.'
+        : product.isNewIntro
+          ? 'Nice pick—new intros love a storytelling moment nearby.'
+          : 'Added to your selection.'
+    );
+  };
+
+  const handleFavorite = (actor: string) => {
+    if (!selection) return;
+    const result = toggleFavorite(product.sku, actor, product.collectionId);
+    if (result.status === 'denied') {
+      setFavoriteFeedback('Max favorites reached in this collection.');
+      return;
+    }
+    if (result.status === 'added') {
+      setFavoriteFeedback(
+        result.remaining > 0
+          ? `Starred! ${result.remaining} favorite${result.remaining === 1 ? '' : 's'} left in this collection.`
+          : 'Starred! You’ve used all favorites here.'
+      );
+    } else {
+      setFavoriteFeedback('Removed from your favorites.');
+    }
+  };
+
+  const onAddClick = () => {
+    if (!ensureName('add')) return;
+    handleAdd(name!);
+  };
+
+  const onFavoriteClick = () => {
+    if (!ensureName('favorite')) return;
+    handleFavorite(name!);
+  };
+
+  const priceLabel = (() => {
+    if (dealer?.priceTier === 'dealer' && product.price.dealerNet) {
+      return `$${product.price.dealerNet.toLocaleString()} dealer net`;
+    }
+    return `$${product.price.msrp.toLocaleString()} MSRP`;
+  })();
+
+  const displayBadge = dealer?.displays.some((item) => item.sku === product.sku);
+
+  return (
+    <div className="group flex h-full flex-col justify-between rounded-3xl bg-white p-4 shadow-sm ring-1 ring-slate-200 transition hover:-translate-y-1 hover:shadow-lg">
+      <div>
+        <div className="relative mb-3 aspect-[4/3] overflow-hidden rounded-2xl bg-slate-100">
+          <Image
+            src={product.images[0]}
+            alt={`${product.title} ${product.sku}`}
+            fill
+            className="object-cover transition duration-300 group-hover:scale-105"
+            sizes="(max-width: 768px) 100vw, 320px"
+          />
+        </div>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+              {product.vendor}
+            </p>
+            <h3 className="mt-1 text-lg font-semibold text-slate-900">{product.title}</h3>
+            <p className="text-sm text-slate-500">SKU {product.sku}</p>
+          </div>
+          <div className="text-right text-sm font-semibold text-brand">{priceLabel}</div>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {product.isNewIntro && (
+            <Badge variant="brand">New Intro</Badge>
+          )}
+          {product.isMarketRecommended && (
+            <Badge variant="accent">Dallas Recommended</Badge>
+          )}
+          {isPreviouslyPurchased && <Badge variant="success">Previously purchased</Badge>}
+          {displayBadge && <Badge variant="neutral">On display</Badge>}
+          {isAdded && <Badge variant="outline">✓ Added</Badge>}
+        </div>
+        <ul className="mt-4 space-y-1 text-sm text-slate-600">
+          {Object.entries(product.specs)
+            .slice(0, 4)
+            .map(([key, value]) => (
+              <li key={key} className="flex justify-between gap-4">
+                <span className="font-medium text-slate-500">{key}</span>
+                <span className="text-right text-slate-700">{String(value)}</span>
+              </li>
+            ))}
+        </ul>
+      </div>
+      <div className="mt-6 space-y-2">
+        <button
+          type="button"
+          onClick={onAddClick}
+          className={clsx(
+            'flex w-full items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition',
+            isAdded
+              ? 'bg-brand/10 text-brand'
+              : 'bg-brand text-white shadow-sm hover:bg-brand-muted'
+          )}
+        >
+          {isAdded ? '✓ Added' : 'Add to Selection'}
+        </button>
+        <button
+          type="button"
+          onClick={onFavoriteClick}
+          className={clsx(
+            'flex w-full items-center justify-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition',
+            isFavorited
+              ? 'border-brand/40 bg-brand/10 text-brand'
+              : 'border-slate-200 bg-white text-slate-600 hover:border-brand/40 hover:text-brand'
+          )}
+        >
+          {isFavorited ? '★ Favorited' : '☆ Favorite'}
+        </button>
+        {(favoriteFeedback || addFeedback) && (
+          <p className="text-xs text-slate-500">
+            {favoriteFeedback ?? addFeedback}
+          </p>
+        )}
+      </div>
+      <AttributionPrompt
+        open={promptOpen}
+        defaultValue={name}
+        onClose={() => {
+          setPromptOpen(false);
+          setPendingAction(null);
+        }}
+        onSubmit={(newName) => {
+          saveName(newName);
+          if (!selection) return;
+          if (pendingAction === 'add') {
+            handleAdd(newName);
+          } else if (pendingAction === 'favorite') {
+            handleFavorite(newName);
+          }
+          setPendingAction(null);
+        }}
+      />
+    </div>
+  );
+}
+
+type BadgeProps = {
+  children: React.ReactNode;
+  variant?: 'brand' | 'accent' | 'success' | 'outline' | 'neutral';
+};
+
+function Badge({ children, variant = 'brand' }: BadgeProps) {
+  const classes = {
+    brand: 'bg-brand/10 text-brand',
+    accent: 'bg-brand-accent/10 text-brand-accent',
+    success: 'bg-emerald-100 text-emerald-700',
+    outline: 'border border-brand/40 text-brand',
+    neutral: 'bg-slate-100 text-slate-600',
+  }[variant];
+  return (
+    <span className={clsx('rounded-full px-3 py-1 text-xs font-semibold', classes)}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/icons/ArrowRightIcon.tsx
+++ b/src/components/icons/ArrowRightIcon.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { SVGProps } from 'react';
+
+export function ArrowRightIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.5 4.5 21 12l-7.5 7.5M21 12H3"
+      />
+    </svg>
+  );
+}

--- a/src/hooks/useAttribution.ts
+++ b/src/hooks/useAttribution.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'showroom-attribution-name';
+
+export function useAttributionName() {
+  const [name, setName] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      setName(stored);
+    }
+    setReady(true);
+  }, []);
+
+  const saveName = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setName(trimmed);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, trimmed);
+    }
+  };
+
+  return { name, ready, saveName };
+}

--- a/src/hooks/useSelectionStore.ts
+++ b/src/hooks/useSelectionStore.ts
@@ -1,0 +1,181 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+import type { Selection, SelectionLine } from '@/lib/types';
+
+export type SelectionStore = {
+  selection?: Selection;
+  collaborators: string[];
+  favoriteLedger: Record<string, Record<string, number>>;
+  initialize: (selection: Selection) => void;
+  setCollaborator: (name: string) => void;
+  addLine: (line: SelectionLine, actor: string) => void;
+  removeLine: (sku: string) => void;
+  updateQty: (sku: string, qty: number) => void;
+  updateNotes: (sku: string, notes: string) => void;
+  toggleFavorite: (
+    sku: string,
+    actor: string,
+    collectionId: string,
+    limit?: number
+  ) => { status: 'added' | 'removed' | 'denied'; remaining: number };
+  clear: () => void;
+  replaceSelection: (selection: Selection) => void;
+};
+
+const MAX_FAVORITES_PER_COLLECTION = 5;
+
+type PersistedState = Pick<SelectionStore, 'selection' | 'collaborators' | 'favoriteLedger'>;
+
+export const useSelectionStore = create<SelectionStore>()(
+  persist(
+    immer((set) => ({
+      selection: undefined,
+      collaborators: [],
+      favoriteLedger: {},
+      initialize: (selection) => {
+        set((state) => {
+          state.selection = selection;
+          state.favoriteLedger = buildLedger(selection);
+          state.collaborators = deriveCollaborators(selection);
+        });
+      },
+      setCollaborator: (name) => {
+        if (!name.trim()) return;
+        set((state) => {
+          if (!state.collaborators.includes(name)) {
+            state.collaborators.push(name);
+          }
+        });
+      },
+      addLine: (line, actor) => {
+        set((state) => {
+          if (!state.selection) return;
+          const existing = state.selection.lines.find((l) => l.sku === line.sku);
+          if (existing) {
+            existing.qty += line.qty;
+            if (!existing.pickedBy.includes(actor)) {
+              existing.pickedBy.push(actor);
+            }
+          } else {
+            state.selection.lines.push({ ...line, pickedBy: [actor], favorites: [] });
+          }
+          state.selection.updatedAt = new Date().toISOString();
+          if (!state.collaborators.includes(actor)) {
+            state.collaborators.push(actor);
+          }
+        });
+      },
+      removeLine: (sku) => {
+        set((state) => {
+          if (!state.selection) return;
+          state.selection.lines = state.selection.lines.filter((line) => line.sku !== sku);
+          state.selection.updatedAt = new Date().toISOString();
+        });
+      },
+      updateQty: (sku, qty) => {
+        set((state) => {
+          if (!state.selection) return;
+          const line = state.selection.lines.find((l) => l.sku === sku);
+          if (!line) return;
+          line.qty = qty;
+          state.selection.updatedAt = new Date().toISOString();
+        });
+      },
+      updateNotes: (sku, notes) => {
+        set((state) => {
+          if (!state.selection) return;
+          const line = state.selection.lines.find((l) => l.sku === sku);
+          if (!line) return;
+          line.notes = notes;
+          state.selection.updatedAt = new Date().toISOString();
+        });
+      },
+      toggleFavorite: (sku, actor, collectionId, limit = MAX_FAVORITES_PER_COLLECTION) => {
+        let result: { status: 'added' | 'removed' | 'denied'; remaining: number } = {
+          status: 'denied',
+          remaining: 0,
+        };
+        set((state) => {
+          if (!state.selection) return;
+          const line = state.selection.lines.find((l) => l.sku === sku);
+          if (!line) return;
+          const ledger = state.favoriteLedger[collectionId] ?? {};
+          const currentCount = ledger[actor] ?? 0;
+          const hasFavorite = line.favorites.includes(actor);
+
+          if (hasFavorite) {
+            line.favorites = line.favorites.filter((name) => name !== actor);
+            ledger[actor] = Math.max(0, currentCount - 1);
+            result = { status: 'removed', remaining: limit - (ledger[actor] ?? 0) };
+          } else {
+            if (currentCount >= limit) {
+              result = { status: 'denied', remaining: 0 };
+              return;
+            }
+            line.favorites.push(actor);
+            ledger[actor] = currentCount + 1;
+            result = { status: 'added', remaining: limit - ledger[actor] };
+          }
+
+          state.favoriteLedger[collectionId] = ledger;
+          state.selection.updatedAt = new Date().toISOString();
+          if (!state.collaborators.includes(actor)) {
+            state.collaborators.push(actor);
+          }
+        });
+
+        return result;
+      },
+      clear: () => {
+        set((state) => {
+          if (!state.selection) return;
+          state.selection.lines = [];
+          state.selection.updatedAt = new Date().toISOString();
+          state.favoriteLedger = {};
+        });
+      },
+      replaceSelection: (selection) => {
+        set((state) => {
+          state.selection = selection;
+          state.favoriteLedger = buildLedger(selection);
+          state.collaborators = deriveCollaborators(selection);
+        });
+      },
+    })),
+    {
+      name: 'selection-store',
+      partialize: (state) => ({
+        selection: state.selection,
+        collaborators: state.collaborators,
+        favoriteLedger: state.favoriteLedger,
+      } satisfies PersistedState),
+    }
+  )
+);
+
+function buildLedger(selection: Selection | undefined) {
+  const ledger: Record<string, Record<string, number>> = {};
+  if (!selection) return ledger;
+  for (const line of selection.lines) {
+    if (!line.collectionId) continue;
+    if (!ledger[line.collectionId]) ledger[line.collectionId] = {};
+    for (const name of line.favorites) {
+      const entry = ledger[line.collectionId][name] ?? 0;
+      ledger[line.collectionId][name] = entry + 1;
+    }
+  }
+  return ledger;
+}
+
+function deriveCollaborators(selection: Selection | undefined) {
+  if (!selection) return [] as string[];
+  const names = new Set<string>();
+  for (const line of selection.lines) {
+    line.pickedBy.forEach((name) => names.add(name));
+    line.favorites.forEach((name) => names.add(name));
+  }
+  return Array.from(names);
+}

--- a/src/lib/dataClient.ts
+++ b/src/lib/dataClient.ts
@@ -1,0 +1,156 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nanoid } from 'nanoid';
+import { hasSupabaseConfig } from './env';
+import type {
+  Collection,
+  DealerProfile,
+  Product,
+  Selection,
+} from './types';
+
+const dataDir = join(process.cwd(), 'data');
+
+async function readJson<T>(fileName: string): Promise<T> {
+  const filePath = join(dataDir, fileName);
+  const raw = await readFile(filePath, 'utf-8');
+  return JSON.parse(raw) as T;
+}
+
+async function writeJson<T>(fileName: string, data: T) {
+  const filePath = join(dataDir, fileName);
+  await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+export async function getCollections(): Promise<Collection[]> {
+  if (hasSupabaseConfig()) {
+    const { createClient } = await import('@supabase/supabase-js');
+    const client = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+    const { data, error } = await client
+      .from('collections')
+      .select('*')
+      .order('sortOrder', { ascending: true });
+    if (error) throw error;
+    return data as Collection[];
+  }
+  const local = await readJson<Collection[]>('collections.json');
+  return local.sort((a, b) => a.sortOrder - b.sortOrder);
+}
+
+export async function getProducts(): Promise<Product[]> {
+  if (hasSupabaseConfig()) {
+    const { createClient } = await import('@supabase/supabase-js');
+    const client = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+    const { data, error } = await client
+      .from('products')
+      .select('*')
+      .eq('active', true);
+    if (error) throw error;
+    return data as Product[];
+  }
+  const products = await readJson<Product[]>('products.json');
+  return products.filter((product) => product.active);
+}
+
+export async function getDealerProfile(id: string): Promise<DealerProfile | null> {
+  if (hasSupabaseConfig()) {
+    const { createClient } = await import('@supabase/supabase-js');
+    const client = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+    const { data, error } = await client
+      .from('dealers')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    return data as DealerProfile | null;
+  }
+  const dealers = await readJson<DealerProfile[]>('dealers.json');
+  return dealers.find((dealer) => dealer.id === id) ?? null;
+}
+
+export async function getSelectionById(id: string): Promise<Selection | null> {
+  if (hasSupabaseConfig()) {
+    const { createClient } = await import('@supabase/supabase-js');
+    const client = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+    const { data, error } = await client
+      .from('selections')
+      .select('*, lines:selection_lines(*)')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    return {
+      id: data.id,
+      dealerId: data.dealerId,
+      name: data.name,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+      lines: data.lines,
+    } as Selection;
+  }
+
+  try {
+    const selection = await readJson<Selection>('selection.example.json');
+    return selection.id === id ? selection : null;
+  } catch (error) {
+    console.error('Selection read error', error);
+    return null;
+  }
+}
+
+export async function upsertSelection(selection: Selection): Promise<Selection> {
+  if (hasSupabaseConfig()) {
+    const { createClient } = await import('@supabase/supabase-js');
+    const client = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+    const { data, error } = await client
+      .from('selections')
+      .upsert(selection)
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    return data as Selection;
+  }
+
+  await writeJson('selection.example.json', selection);
+  return selection;
+}
+
+export async function createSelectionFromTemplate(
+  dealerId: string,
+  template?: Partial<Selection>
+) {
+  const selection: Selection = {
+    id: template?.id ?? `sel_${nanoid(8)}`,
+    dealerId,
+    name: template?.name ?? 'Market Selection (Draft)',
+    lines: template?.lines ?? [],
+    createdAt: template?.createdAt ?? new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  return upsertSelection(selection);
+}
+
+const shareCache = new Map<string, { selectionId: string; createdAt: string }>();
+
+export function persistShareToken(token: string, selectionId: string) {
+  shareCache.set(token, { selectionId, createdAt: new Date().toISOString() });
+}
+
+export function resolveShareToken(token: string): string | null {
+  return shareCache.get(token)?.selectionId ?? null;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,8 @@
+export function hasSupabaseConfig() {
+  return (
+    typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
+    process.env.NEXT_PUBLIC_SUPABASE_URL.length > 0 &&
+    typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 0
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,68 @@
+export type PriceTiers = {
+  msrp: number;
+  dealerNet?: number;
+  map?: number;
+};
+
+export type Product = {
+  sku: string;
+  title: string;
+  vendor: 'Lib&Co' | 'Savoy House' | 'Hubbardton Forge' | string;
+  images: string[];
+  videoUrls?: string[];
+  specs: {
+    'Collection name'?: string;
+    'Number of Bulbs'?: string | number;
+    'Finish'?: string;
+    size?: string;
+    dimmable?: boolean;
+    [k: string]: unknown;
+  };
+  collectionId: string;
+  price: PriceTiers;
+  isNewIntro?: boolean;
+  isMarketRecommended?: boolean;
+  active: boolean;
+};
+
+export type Collection = {
+  id: string;
+  name: string;
+  heroVideoUrl?: string;
+  description?: string;
+  sortOrder: number;
+};
+
+export type DealerDisplayItem = { sku: string; installedAt?: string };
+
+export type DealerProfile = {
+  id: string;
+  name: string;
+  priceTier: 'dealer' | 'msrpOnly';
+  displays: DealerDisplayItem[];
+  previouslyPurchasedSkus: string[];
+  starterSelectionSkus?: string[];
+};
+
+export type SelectionLine = {
+  sku: string;
+  qty: number;
+  notes?: string;
+  pickedBy: string[];
+  favorites: string[];
+  collectionId?: string;
+};
+
+export type Selection = {
+  id: string;
+  dealerId: string;
+  name: string;
+  lines: SelectionLine[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SharePayload = {
+  token: string;
+  selectionId: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+      },
+      colors: {
+        brand: {
+          DEFAULT: '#233E8B',
+          muted: '#3A5BA0',
+          accent: '#F6AE2D',
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src/**/*", "next.config.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js + Tailwind showroom presentation app with seeded collections, products, and dealer data
- implement showroom experience with recommendation rows, collection sections, collaborative selection panel, and attribution prompts backed by a Zustand store
- add API routes for data access, sharing, and PDF/CSV exports alongside documentation for local JSON and optional Supabase usage

## Testing
- not run (dependencies unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cd903baa48832ba26186364a56498c